### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "hass_ollama_image_analysis",
   "name": "Ollama (local AI models) image analysis",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "codeowners": [
     "@the-smart-home-maker"
   ],


### PR DESCRIPTION
Updated version number in Manifest.json from 0.1.0 to 0.1.2 as the Github version has been updated from 0.1.0 to 0.1.1.

this means that HACS doesnt detect there is a an update, and doesnt push the change down to clients.

This fixes #3 and extends the changes in #4 